### PR TITLE
Update Parquet version to use new Filtered Api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <shadeBase>com.facebook.presto.hive.shaded</shadeBase>
         <dep.slf4j.version>1.6.6</dep.slf4j.version>
         <dep.hive.version>0.13.1</dep.hive.version>
-        <dep.parquet.version>1.3.2</dep.parquet.version>
+        <dep.parquet.version>1.6.0rc1</dep.parquet.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Parquet filter2 package has the new Filtered Api implementation
While, 1.6.0 has not been released yet
could use 1.6.0rc1 