### PR TITLE
Fix compressor/decompressor leak

### DIFF
--- a/src/main/java/org/apache/hadoop/hive/ql/io/CodecPool.java
+++ b/src/main/java/org/apache/hadoop/hive/ql/io/CodecPool.java
@@ -37,11 +37,11 @@ public final class CodecPool
 
     public static void returnCompressor(Compressor compressor)
     {
-        // no-op
+        compressor.end();
     }
 
     public static void returnDecompressor(Decompressor decompressor)
     {
-        // no-op
+        decompressor.end();
     }
 }


### PR DESCRIPTION
This fixes a leak of Compressor and Decompressor objects which can lead
to leaked native memory, if a native codec is used.