### PR TITLE
Include Avro support in presto-hive-apache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,6 @@
                                         <exclude>javaewah/**</exclude>
                                         <exclude>javax/realtime/**</exclude>
                                         <exclude>javolution/**</exclude>
-                                        <exclude>org/apache/avro/**</exclude>
                                         <exclude>org/apache/thrift/**</exclude>
                                         <exclude>*.properties</exclude>
                                         <exclude>*.jar</exclude>


### PR DESCRIPTION
Since Avro related classes are currently excluded in presto-hive-apache, NoClassDefFoundError are risen when querying a table from Hive catalog with Avro data. The same query succeed by including these Avro classes into presto-hive-apache.

> 2016-04-04T23:22:00.303Z        ERROR   Query-20160404_232200_00152_m7etj-60601 com.facebook.presto.execution.QueryStateMachine Query 20160404_232200_00152_m7etj failed
java.lang.NoClassDefFoundError: org/apache/avro/Schema$Parser
        at org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.getSchemaFor(AvroSerdeUtils.java:212)
        at org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.determineSchemaOrThrowException(AvroSerdeUtils.java:104)
        at org.apache.hadoop.hive.serde2.avro.AvroSerDe.determineSchemaOrReturnErrorSchema(AvroSerDe.java:167)
        at org.apache.hadoop.hive.serde2.avro.AvroSerDe.initialize(AvroSerDe.java:103)
        at com.facebook.presto.hive.HiveUtil.initializeDeserializer(HiveUtil.java:335)
        at com.facebook.presto.hive.HiveUtil.getDeserializer(HiveUtil.java:297)
        at com.facebook.presto.hive.HiveUtil.getTableObjectInspector(HiveUtil.java:259)
        at com.facebook.presto.hive.HiveUtil.getTableStructFields(HiveUtil.java:276)
        at com.facebook.presto.hive.HiveUtil.hiveColumnHandles(HiveUtil.java:514)
        at com.facebook.presto.hive.HiveMetadata.getTableMetadata(HiveMetadata.java:185)
        at com.facebook.presto.hive.HiveMetadata.getTableMetadata(HiveMetadata.java:176)
        at com.facebook.presto.spi.classloader.ClassLoaderSafeConnectorMetadata.getTableMetadata(ClassLoaderSafeConnectorMetadata.java:92)
        at com.facebook.presto.metadata.MetadataManager.getTableMetadata(MetadataManager.java:318)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitTable(TupleAnalyzer.java:243)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitTable(TupleAnalyzer.java:135)
        at com.facebook.presto.sql.tree.Table.accept(Table.java:36)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.analyzeFrom(TupleAnalyzer.java:982)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:349)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:135)
        at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:98)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:529)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:115)
        at com.facebook.presto.sql.tree.Query.accept(Query.java:80)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:52)
        at com.facebook.presto.execution.SqlQueryExecution.doAnalyzeQuery(SqlQueryExecution.java:251)
        at com.facebook.presto.execution.SqlQueryExecution.analyzeQuery(SqlQueryExecution.java:237)
        at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:201)
        at com.facebook.presto.execution.QueuedExecution.lambda$start$202(QueuedExecution.java:68)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: org.apache.avro.Schema$Parser
        at com.facebook.presto.server.PluginClassLoader.loadClass(PluginClassLoader.java:106)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 34 more