### PR TITLE
Switch AVRO InstanceCache to use Caffeine cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.6.1</version>
+        </dependency>
+
         <!-- include the sources for Parquet -->
         <dependency>
             <groupId>com.twitter</groupId>

--- a/src/main/java/org/apache/hadoop/hive/serde2/avro/InstanceCache.java
+++ b/src/main/java/org/apache/hadoop/hive/serde2/avro/InstanceCache.java
@@ -13,20 +13,19 @@
  */
 package org.apache.hadoop.hive.serde2.avro;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Cache;
 
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
- * This is a thread-safe, time-bounded fork of the Hive version.
+ * This is a thread-safe, size-bounded fork of the Hive version.
  * It also includes the correctness fix from HIVE-11288.
  */
 public abstract class InstanceCache<K, V>
 {
-    private final Cache<K, V> cache = CacheBuilder.newBuilder()
-            .expireAfterWrite(1, TimeUnit.MINUTES)
+    private final Cache<K, V> cache = Caffeine.newBuilder()
+            .maximumSize(100_000)
             .build();
 
     protected InstanceCache() {}


### PR DESCRIPTION
Switch AVRO InstanceCache to use Caffeine cache

The InstanceCache was made time based cache to workaround
google/guava#2408 as a part of 1d2f31e. The time-based cache did not
work for all workloads, especially with the hardcoded 1 MINUTE ttl
value. In addition the default concurrencyLevel of 4 was not good
enough for the cache to work out-of-the-box. So switch the
InstanceCache to use size-based Caffeine
(https://github.com/ben-manes/caffeine) cache which has the fix for
the original guava bug google/guava#2408.

Also in terms of concurrencyLevel switching to Caffeine helps.
From https://github.com/ben-manes/caffeine/wiki/Benchmarks:
"Caffeine and ConcurrentLinkedHashMap size their internal
structures based on the number of CPUs"
