### PR TITLE
Retain logging from Hive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     </properties>
 
     <dependencies>
-        <!-- discard logging from hive -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
@@ -56,7 +55,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
+            <artifactId>slf4j-jdk14</artifactId>
             <version>${dep.slf4j.version}</version>
         </dependency>
 


### PR DESCRIPTION
When logging it silenced from Hive as a whole, it makes it cumbersome to troubleshoot problems with Avro.
This is because `AvroSerDe` logs errors instead of rethrowing them. 
https://github.com/apache/hive/blob/e161b01136ea14d1f9358d9b71aea61951bfaab0/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerDe.java#L197-L202

While, same AvroSerDe logs a log on INFO level, we should address the problem with pre-packaged `log.properties` file.