### PR TITLE
Exclude transitive dependencies introduced by Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,26 @@
                     <groupId>sqlline</groupId>
                     <artifactId>sqlline</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-compat-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.facebook.presto.hive</groupId>
     <artifactId>hive-apache</artifactId>
-    <version>3.0.0-2</version>
+    <version>3.0.0-3-SNAPSHOT</version>
 
     <name>hive-apache</name>
     <description>Shaded version of Apache Hive for Presto</description>
@@ -34,7 +34,7 @@
         <connection>scm:git:git://github.com/prestodb/presto-hive-apache.git</connection>
         <developerConnection>scm:git:git://github.com/prestodb/presto-hive-apache.git</developerConnection>
         <url>https://github.com/prestodb/presto-hive-apache</url>
-        <tag>3.0.0-2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.facebook.presto.hive</groupId>
     <artifactId>hive-apache</artifactId>
-    <version>3.0.0-2-SNAPSHOT</version>
+    <version>3.0.0-2</version>
 
     <name>hive-apache</name>
     <description>Shaded version of Apache Hive for Presto</description>
@@ -34,7 +34,7 @@
         <connection>scm:git:git://github.com/prestodb/presto-hive-apache.git</connection>
         <developerConnection>scm:git:git://github.com/prestodb/presto-hive-apache.git</developerConnection>
         <url>https://github.com/prestodb/presto-hive-apache</url>
-        <tag>HEAD</tag>
+        <tag>3.0.0-2</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
These were causing duplicates in the presto build. Missed it because my alias for fast builds skipped the checks.