### PR TITLE
Fix JsonSerDe parsing performance

### DIFF
--- a/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
+++ b/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
@@ -173,6 +173,9 @@ public class JsonSerDe extends AbstractSerDe {
         // iterate through each token, and create appropriate object here.
         populateRecord(r, token, p, schema);
       }
+      // Calling close on the parser even though there is no real InputStream backing it is necessary so that
+      // entries in this parser instance's canonical field name cache can be reused on the next invocation
+      p.close();
     } catch (JsonParseException e) {
       LOG.warn("Error [{}] parsing json text [{}].", e, t);
       throw new SerDeException(e);

--- a/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
+++ b/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
@@ -13,7 +13,6 @@
  */
 package org.apache.hive.hcatalog.data;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.CharacterCodingException;
 import java.sql.Date;
@@ -164,7 +163,7 @@ public class JsonSerDe extends AbstractSerDe {
     JsonParser p;
     List<Object> r = new ArrayList<Object>(Collections.nCopies(columnNames.size(), null));
     try {
-      p = jsonFactory.createJsonParser(new ByteArrayInputStream((t.getBytes())));
+      p = jsonFactory.createJsonParser(t.getBytes(), 0, t.getLength());
       if (p.nextToken() != JsonToken.START_OBJECT) {
         throw new IOException("Start token not found where expected");
       }

--- a/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
+++ b/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
@@ -144,7 +144,8 @@ public class JsonSerDe extends AbstractSerDe {
       throw new SerDeException(e);
     }
 
-    jsonFactory = new JsonFactory();
+    // Interning all encountered field names improves little compared to the per-factory canonical name cache and can cause native memory issues
+    jsonFactory = new JsonFactory().disable(JsonParser.Feature.INTERN_FIELD_NAMES);
     tsParser = new TimestampParser(
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS)));
   }


### PR DESCRIPTION
Fixes the same problem previously observed by https://github.com/trinodb/trino-hive-apache/pull/12 but without fully abandoning field name canonicalization. JsonSerDe was creating such extreme lock contention as to effectively become single-threaded across a whole machine when parsing JSON, but:
- The lock contention issue likely would subside after reaching a steady state if the canonical field name cache wasn't being discarded and re-created for each parsed row
- Field name interning can cause it's own problems with GC roots and native memory consumption, but a per `JsonFactory` canonical field name cache that _doesn't_ intern has almost identical performance without that downside and much better performance than disabling it entirely. Solution: only disable `INTERN_FIELD_NAMES` but leave `CANONICALIZE_FIELD_NAMES` enabled

Also avoids creating a temporary I/O buffer and intermediate copies during parsing by passing the byte array to parse directly into `JsonFactory#createJsonParser`.

The net effect is that this change typically improves JSON parsing performance by a multiple of worker node CPU core count by fixing the contention issue and does not degrade single threaded parsing performance. In my particular test environment with 16 physical cores and 32 hyperthreads, this improvement reduces overall execution time of the entire TPCH suite to 1/17th of the baseline.