### PR TITLE
Upgrade parquet to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
 
         <dep.hive.version>3.0.0</dep.hive.version>
 
-        <dep.avro.version>1.8.2</dep.avro.version>
+        <dep.avro.version>1.9.1</dep.avro.version>
         <dep.jodd.version>3.5.2</dep.jodd.version>
-        <dep.parquet.version>1.10.1</dep.parquet.version>
+        <dep.parquet.version>1.11.0</dep.parquet.version>
         <dep.protobuf.version>2.5.0</dep.protobuf.version>
         <dep.slf4j.version>1.7.25</dep.slf4j.version>
 

--- a/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
+++ b/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
@@ -27,6 +27,10 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -75,10 +79,6 @@ import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
 import org.apache.hive.hcatalog.data.schema.HCatFieldSchema.Type;
 import org.apache.hive.hcatalog.data.schema.HCatSchema;
 import org.apache.hive.hcatalog.data.schema.HCatSchemaUtils;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +144,7 @@ public class JsonSerDe extends AbstractSerDe {
     }
 
     // Interning all encountered field names improves little compared to the per-factory canonical name cache and can cause native memory issues
-    jsonFactory = new JsonFactory().disable(JsonParser.Feature.INTERN_FIELD_NAMES);
+    jsonFactory = new JsonFactory();
     tsParser = new TimestampParser(
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS)));
   }


### PR DESCRIPTION
The [icerberg connector](https://github.com/prestodb/presto/pull/15836) is using Parquet 1.11.0. There will be a dependency conflict error during the compilation. This PR helps to upgrade Parquet to 1.11.0.
