### PR TITLE
Fix NoClassDefFoundError for JsonNode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,18 @@
             <version>1.7</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+
         <!-- hive -->
         <dependency>
             <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
When rolling out hive-apache-3.0.0-5 to Presto ([PR](https://github.com/prestodb/presto/pull/16545)), here are error message: 

java.lang.NoClassDefFoundError: com/facebook/presto/hive/$internal/org/codehaus/jackson/JsonNode
presto-worker_1       | 	at org.apache.hadoop.hive.serde2.avro.AvroSerDe.getSchemaFromCols(AvroSerDe.java:178)

After investigation, it turned out we need to make this change to solve that. 