### PR TITLE
[WIP]Fix avro test failures in prestodb project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -791,6 +791,9 @@
                                     <artifact>org.apache.hive:hive-serde</artifact>
                                     <excludes>
                                         <exclude>org/apache/hadoop/hive/serde2/avro/InstanceCache*.class</exclude>
+                                        <exclude>org/apache/hadoop/hive/serde2/avro/TypeInfoToSchema*.class</exclude>
+                                        <exclude>org/apache/hadoop/hive/serde2/avro/SchemaToTypeInfo*.class</exclude>
+                                        <exclude>org/apache/hadoop/hive/serde2/avro/AvroDeserializer*.class</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>

--- a/src/main/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
+++ b/src/main/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.serde2.avro;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.rmi.server.UID;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Fixed;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.UnresolvedUnionException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.common.type.HiveChar;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardUnionObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
+import org.apache.hadoop.io.Writable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AvroDeserializer {
+  private static final Logger LOG = LoggerFactory.getLogger(AvroDeserializer.class);
+  /**
+   * Set of already seen and valid record readers IDs which doesn't need re-encoding
+   */
+  private final HashSet<UID> noEncodingNeeded = new HashSet<UID>();
+  /**
+   * Map of record reader ID and the associated re-encoder. It contains only the record readers
+   *  that record needs to be re-encoded.
+   */
+  private final HashMap<UID, SchemaReEncoder> reEncoderCache = new HashMap<UID, SchemaReEncoder>();
+  /**
+   * Flag to print the re-encoding warning message only once. Avoid excessive logging for each
+   * record encoding.
+   */
+  private boolean warnedOnce = false;
+  /**
+   * When encountering a record with an older schema than the one we're trying
+   * to read, it is necessary to re-encode with a reader against the newer schema.
+   * Because Hive doesn't provide a way to pass extra information to the
+   * inputformat, we're unable to provide the newer schema when we have it and it
+   * would be most useful - when the inputformat is reading the file.
+   *
+   * This is a slow process, so we try to cache as many of the objects as possible.
+   */
+  static class SchemaReEncoder {
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    private final GenericDatumWriter<GenericRecord> gdw = new GenericDatumWriter<GenericRecord>();
+    private BinaryDecoder binaryDecoder = null;
+
+    GenericDatumReader<GenericRecord> gdr = null;
+
+    public SchemaReEncoder(Schema writer, Schema reader) {
+      gdr = new GenericDatumReader<GenericRecord>(writer, reader);
+    }
+
+    public GenericRecord reencode(GenericRecord r)
+        throws AvroSerdeException {
+      baos.reset();
+
+      BinaryEncoder be = EncoderFactory.get().directBinaryEncoder(baos, null);
+      gdw.setSchema(r.getSchema());
+      try {
+        gdw.write(r, be);
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+
+        binaryDecoder = DecoderFactory.defaultFactory().createBinaryDecoder(bais, binaryDecoder);
+
+        return gdr.read(r, binaryDecoder);
+
+      } catch (IOException e) {
+        throw new AvroSerdeException("Exception trying to re-encode record to new schema", e);
+      }
+    }
+  }
+
+  private List<Object> row;
+
+  /**
+   * Deserialize an Avro record, recursing into its component fields and
+   * deserializing them as well.  Fields of the record are matched by name
+   * against fields in the Hive row.
+   *
+   * Because Avro has some data types that Hive does not, these are converted
+   * during deserialization to types Hive will work with.
+   *
+   * @param columnNames List of columns Hive is expecting from record.
+   * @param columnTypes List of column types matched by index to names
+   * @param writable Instance of GenericAvroWritable to deserialize
+   * @param readerSchema Schema of the writable to deserialize
+   * @return A list of objects suitable for Hive to work with further
+   * @throws AvroSerdeException For any exception during deseriliazation
+   */
+  public Object deserialize(List<String> columnNames, List<TypeInfo> columnTypes,
+      Writable writable, Schema readerSchema) throws AvroSerdeException {
+    if(!(writable instanceof AvroGenericRecordWritable)) {
+      throw new AvroSerdeException("Expecting a AvroGenericRecordWritable");
+    }
+
+    if(row == null || row.size() != columnNames.size()) {
+      row = new ArrayList<Object>(columnNames.size());
+    } else {
+      row.clear();
+    }
+
+    AvroGenericRecordWritable recordWritable = (AvroGenericRecordWritable) writable;
+    GenericRecord r = recordWritable.getRecord();
+    Schema fileSchema = recordWritable.getFileSchema();
+
+    UID recordReaderId = recordWritable.getRecordReaderID();
+    //If the record reader (from which the record is originated) is already seen and valid,
+    //no need to re-encode the record.
+    if(!noEncodingNeeded.contains(recordReaderId)) {
+      SchemaReEncoder reEncoder = null;
+      //Check if the record record is already encoded once. If it does
+      //reuse the encoder.
+      if(reEncoderCache.containsKey(recordReaderId)) {
+        reEncoder = reEncoderCache.get(recordReaderId); //Reuse the re-encoder
+      } else if (!r.getSchema().equals(readerSchema)) { //Evolved schema?
+        //Create and store new encoder in the map for re-use
+        reEncoder = new SchemaReEncoder(r.getSchema(), readerSchema);
+        reEncoderCache.put(recordReaderId, reEncoder);
+      } else{
+        LOG.debug("Adding new valid RRID :" +  recordReaderId);
+        noEncodingNeeded.add(recordReaderId);
+      }
+      if(reEncoder != null) {
+        if (!warnedOnce) {
+          LOG.warn("Received different schemas.  Have to re-encode: " +
+              r.getSchema().toString(false) + "\nSIZE" + reEncoderCache + " ID " + recordReaderId);
+          warnedOnce = true;
+        }
+        r = reEncoder.reencode(r);
+      }
+    }
+
+    workerBase(row, fileSchema, columnNames, columnTypes, r);
+    return row;
+  }
+
+  // The actual deserialization may involve nested records, which require recursion.
+  private List<Object> workerBase(List<Object> objectRow, Schema fileSchema, List<String> columnNames,
+      List<TypeInfo> columnTypes, GenericRecord record)
+      throws AvroSerdeException {
+    for(int i = 0; i < columnNames.size(); i++) {
+      TypeInfo columnType = columnTypes.get(i);
+      String columnName = columnNames.get(i);
+      Object datum = record.get(columnName);
+      Schema datumSchema = record.getSchema().getField(columnName).schema();
+      Schema.Field field = AvroSerdeUtils.isNullableType(fileSchema)?AvroSerdeUtils.getOtherTypeFromNullableType(fileSchema).getField(columnName):fileSchema.getField(columnName);
+      objectRow.add(worker(datum, field == null ? null : field.schema(), datumSchema, columnType));
+    }
+
+    return objectRow;
+  }
+
+  private Object worker(Object datum, Schema fileSchema, Schema recordSchema, TypeInfo columnType)
+      throws AvroSerdeException {
+    if (datum == null) {
+      return null;
+    }
+
+    // Avro requires nullable types to be defined as unions of some type T
+    // and NULL. This is annoying and we're going to hide it from the user.
+
+    if (AvroSerdeUtils.isNullableType(recordSchema)) {
+      recordSchema = AvroSerdeUtils.getOtherTypeFromNullableType(recordSchema);
+    }
+    if (fileSchema != null && AvroSerdeUtils.isNullableType(fileSchema)) {
+      fileSchema = AvroSerdeUtils.getOtherTypeFromNullableType(fileSchema);
+    }
+
+    switch(columnType.getCategory()) {
+      case STRUCT:
+        return deserializeStruct((GenericData.Record) datum, fileSchema, (StructTypeInfo) columnType);
+      case UNION:
+        return deserializeUnion(datum, fileSchema, recordSchema, (UnionTypeInfo) columnType);
+      case LIST:
+        return deserializeList(datum, fileSchema, recordSchema, (ListTypeInfo) columnType);
+      case MAP:
+        return deserializeMap(datum, fileSchema, recordSchema, (MapTypeInfo) columnType);
+      case PRIMITIVE:
+        return deserializePrimitive(datum, fileSchema, recordSchema, (PrimitiveTypeInfo) columnType);
+      default:
+        throw new AvroSerdeException("Unknown TypeInfo: " + columnType.getCategory());
+    }
+  }
+
+  private Object deserializePrimitive(Object datum, Schema fileSchema, Schema recordSchema,
+      PrimitiveTypeInfo columnType) throws AvroSerdeException {
+    switch (columnType.getPrimitiveCategory()){
+      case STRING:
+        return datum.toString(); // To workaround AvroUTF8
+      // This also gets us around the Enum issue since we just take the value
+      // and convert it to a string. Yay!
+      case BINARY:
+        if (recordSchema.getType() == Type.FIXED){
+          Fixed fixed = (Fixed) datum;
+          return fixed.bytes();
+        } else if (recordSchema.getType() == Type.BYTES){
+          return AvroSerdeUtils.getBytesFromByteBuffer((ByteBuffer) datum);
+        } else {
+          throw new AvroSerdeException("Unexpected Avro schema for Binary TypeInfo: " + recordSchema.getType());
+        }
+      case DECIMAL:
+        if (fileSchema == null) {
+          throw new AvroSerdeException("File schema is missing for decimal field. Reader schema is " + columnType);
+        }
+
+        int scale = 0;
+        try {
+          scale = getIntValue(fileSchema.getObjectProp(AvroSerDe.AVRO_PROP_SCALE));
+        } catch(Exception ex) {
+          throw new AvroSerdeException("Failed to obtain scale value from file schema: " + fileSchema, ex);
+        }
+
+        HiveDecimal dec = AvroSerdeUtils.getHiveDecimalFromByteBuffer((ByteBuffer) datum, scale);
+        JavaHiveDecimalObjectInspector oi = (JavaHiveDecimalObjectInspector)
+            PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector((DecimalTypeInfo)columnType);
+        return oi.set(null, dec);
+      case CHAR:
+        if (fileSchema == null) {
+          throw new AvroSerdeException("File schema is missing for char field. Reader schema is " + columnType);
+        }
+
+        int maxLength = 0;
+        try {
+          maxLength = getIntValue(fileSchema.getObjectProp(AvroSerDe.AVRO_PROP_MAX_LENGTH));
+        } catch (Exception ex) {
+          throw new AvroSerdeException("Failed to obtain maxLength value for char field from file schema: " + fileSchema, ex);
+        }
+
+        String str = datum.toString();
+        HiveChar hc = new HiveChar(str, maxLength);
+        return hc;
+      case VARCHAR:
+        if (fileSchema == null) {
+          throw new AvroSerdeException("File schema is missing for varchar field. Reader schema is " + columnType);
+        }
+
+        maxLength = 0;
+        try {
+          maxLength = getIntValue(fileSchema.getObjectProp(AvroSerDe.AVRO_PROP_MAX_LENGTH));
+        } catch (Exception ex) {
+          throw new AvroSerdeException("Failed to obtain maxLength value for varchar field from file schema: " + fileSchema, ex);
+        }
+
+        str = datum.toString();
+        HiveVarchar hvc = new HiveVarchar(str, maxLength);
+        return hvc;
+      case DATE:
+        if (recordSchema.getType() != Type.INT) {
+          throw new AvroSerdeException("Unexpected Avro schema for Date TypeInfo: " + recordSchema.getType());
+        }
+
+        return new Date(DateWritable.daysToMillis((Integer)datum));
+      case TIMESTAMP:
+        if (recordSchema.getType() != Type.LONG) {
+          throw new AvroSerdeException(
+              "Unexpected Avro schema for Date TypeInfo: " + recordSchema.getType());
+        }
+        return new Timestamp((Long)datum);
+      default:
+        return datum;
+    }
+  }
+
+  private static int getIntValue(Object obj) {
+    int value = 0;
+    if (obj instanceof Integer) {
+      value = (int) obj;
+    } else if (obj instanceof String && StringUtils.isNumeric((String)obj)) {
+      value = Integer.parseInt((String)obj);
+    }
+    return value;
+  }
+
+  private Object deserializeStruct(GenericData.Record datum, Schema fileSchema, StructTypeInfo columnType)
+      throws AvroSerdeException {
+    // No equivalent Java type for the backing structure, need to recurse and build a list
+    ArrayList<TypeInfo> innerFieldTypes = columnType.getAllStructFieldTypeInfos();
+    ArrayList<String> innerFieldNames = columnType.getAllStructFieldNames();
+    List<Object> innerObjectRow = new ArrayList<Object>(innerFieldTypes.size());
+
+    return workerBase(innerObjectRow, fileSchema, innerFieldNames, innerFieldTypes, datum);
+  }
+
+  private Object deserializeUnion(Object datum, Schema fileSchema, Schema recordSchema,
+      UnionTypeInfo columnType) throws AvroSerdeException {
+    // Calculate tags individually since the schema can evolve and can have different tags. In worst case, both schemas are same
+    // and we would end up doing calculations twice to get the same tag
+    int fsTag = GenericData.get().resolveUnion(fileSchema, datum); // Determine index of value from fileSchema
+    int rsTag = GenericData.get().resolveUnion(recordSchema, datum); // Determine index of value from recordSchema
+    Object desered = worker(datum, fileSchema == null ? null : fileSchema.getTypes().get(fsTag),
+        recordSchema.getTypes().get(rsTag), columnType.getAllUnionObjectTypeInfos().get(rsTag));
+    return new StandardUnionObjectInspector.StandardUnion((byte)rsTag, desered);
+  }
+
+  private Object deserializeList(Object datum, Schema fileSchema, Schema recordSchema,
+      ListTypeInfo columnType) throws AvroSerdeException {
+    // Need to check the original schema to see if this is actually a Fixed.
+    if(recordSchema.getType().equals(Schema.Type.FIXED)) {
+      // We're faking out Hive to work through a type system impedence mismatch.
+      // Pull out the backing array and convert to a list.
+      GenericData.Fixed fixed = (GenericData.Fixed) datum;
+      List<Byte> asList = new ArrayList<Byte>(fixed.bytes().length);
+      for(int j = 0; j < fixed.bytes().length; j++) {
+        asList.add(fixed.bytes()[j]);
+      }
+      return asList;
+    } else if(recordSchema.getType().equals(Schema.Type.BYTES)) {
+      // This is going to be slow... hold on.
+      ByteBuffer bb = (ByteBuffer)datum;
+      List<Byte> asList = new ArrayList<Byte>(bb.capacity());
+      byte[] array = bb.array();
+      for(int j = 0; j < array.length; j++) {
+        asList.add(array[j]);
+      }
+      return asList;
+    } else { // An actual list, deser its values
+      List listData = (List) datum;
+      Schema listSchema = recordSchema.getElementType();
+      List<Object> listContents = new ArrayList<Object>(listData.size());
+      for(Object obj : listData) {
+        listContents.add(worker(obj, fileSchema == null ? null : fileSchema.getElementType(), listSchema,
+            columnType.getListElementTypeInfo()));
+      }
+      return listContents;
+    }
+  }
+
+  private Object deserializeMap(Object datum, Schema fileSchema, Schema mapSchema, MapTypeInfo columnType)
+      throws AvroSerdeException {
+    // Avro only allows maps with Strings for keys, so we only have to worry
+    // about deserializing the values
+    Map<String, Object> map = new HashMap<String, Object>();
+    Map<CharSequence, Object> mapDatum = (Map)datum;
+    Schema valueSchema = mapSchema.getValueType();
+    TypeInfo valueTypeInfo = columnType.getMapValueTypeInfo();
+    for (CharSequence key : mapDatum.keySet()) {
+      Object value = mapDatum.get(key);
+      map.put(key.toString(), worker(value, fileSchema == null ? null : fileSchema.getValueType(),
+          valueSchema, valueTypeInfo));
+    }
+
+    return map;
+  }
+
+  public HashSet<UID> getNoEncodingNeeded() {
+    return noEncodingNeeded;
+  }
+
+  public HashMap<UID, SchemaReEncoder> getReEncoderCache() {
+    return reEncoderCache;
+  }
+
+}

--- a/src/main/java/org/apache/hadoop/hive/serde2/avro/SchemaToTypeInfo.java
+++ b/src/main/java/org/apache/hadoop/hive/serde2/avro/SchemaToTypeInfo.java
@@ -1,0 +1,293 @@
+/*
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.serde2.avro;
+
+import static org.apache.avro.Schema.Type.BOOLEAN;
+import static org.apache.avro.Schema.Type.BYTES;
+import static org.apache.avro.Schema.Type.DOUBLE;
+import static org.apache.avro.Schema.Type.FIXED;
+import static org.apache.avro.Schema.Type.FLOAT;
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.LONG;
+import static org.apache.avro.Schema.Type.NULL;
+import static org.apache.avro.Schema.Type.STRING;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.HiveDecimalUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+/**
+ * Convert an Avro Schema to a Hive TypeInfo
+ */
+class SchemaToTypeInfo {
+  // Conversion of Avro primitive types to Hive primitive types
+  // Avro             Hive
+  // Null
+  // boolean          boolean    check
+  // int              int        check
+  // long             bigint     check
+  // float            double     check
+  // double           double     check
+  // bytes            binary     check
+  // fixed            binary     check
+  // string           string     check
+  //                  tinyint
+  //                  smallint
+
+  // Map of Avro's primitive types to Hives (for those that are supported by both)
+  private static final Map<Schema.Type, TypeInfo> primitiveTypeToTypeInfo = initTypeMap();
+  private static Map<Schema.Type, TypeInfo> initTypeMap() {
+    Map<Schema.Type, TypeInfo> theMap = new HashMap<Type, TypeInfo>();
+    theMap.put(NULL, TypeInfoFactory.getPrimitiveTypeInfo("void"));
+    theMap.put(BOOLEAN, TypeInfoFactory.getPrimitiveTypeInfo("boolean"));
+    theMap.put(INT, TypeInfoFactory.getPrimitiveTypeInfo("int"));
+    theMap.put(LONG, TypeInfoFactory.getPrimitiveTypeInfo("bigint"));
+    theMap.put(FLOAT, TypeInfoFactory.getPrimitiveTypeInfo("float"));
+    theMap.put(DOUBLE, TypeInfoFactory.getPrimitiveTypeInfo("double"));
+    theMap.put(BYTES, TypeInfoFactory.getPrimitiveTypeInfo("binary"));
+    theMap.put(FIXED, TypeInfoFactory.getPrimitiveTypeInfo("binary"));
+    theMap.put(STRING, TypeInfoFactory.getPrimitiveTypeInfo("string"));
+    return Collections.unmodifiableMap(theMap);
+  }
+
+  /**
+   * Generate a list of of TypeInfos from an Avro schema.  This method is
+   * currently public due to some weirdness in deserializing unions, but
+   * will be made private once that is resolved.
+   * @param schema Schema to generate field types for
+   * @return List of TypeInfos, each element of which is a TypeInfo derived
+   *         from the schema.
+   * @throws AvroSerdeException for problems during conversion.
+   */
+  public static List<TypeInfo> generateColumnTypes(Schema schema) throws AvroSerdeException {
+    return generateColumnTypes (schema, null);
+  }
+
+  /**
+   * Generate a list of of TypeInfos from an Avro schema.  This method is
+   * currently public due to some weirdness in deserializing unions, but
+   * will be made private once that is resolved.
+   * @param schema Schema to generate field types for
+   * @param seenSchemas stores schemas processed in the parsing done so far,
+   *         helping to resolve circular references in the schema
+   * @return List of TypeInfos, each element of which is a TypeInfo derived
+   *         from the schema.
+   * @throws AvroSerdeException for problems during conversion.
+   */
+  public static List<TypeInfo> generateColumnTypes(Schema schema,
+      Set<Schema> seenSchemas) throws AvroSerdeException {
+    List<Schema.Field> fields = schema.getFields();
+
+    List<TypeInfo> types = new ArrayList<TypeInfo>(fields.size());
+
+    for (Schema.Field field : fields) {
+      types.add(generateTypeInfo(field.schema(), seenSchemas));
+    }
+
+    return types;
+  }
+
+  static InstanceCache<Schema, TypeInfo> typeInfoCache = new InstanceCache<Schema, TypeInfo>() {
+    @Override
+    protected TypeInfo makeInstance(Schema s,
+        Set<Schema> seenSchemas)
+        throws AvroSerdeException {
+      return generateTypeInfoWorker(s, seenSchemas);
+    }
+  };
+  /**
+   * Convert an Avro Schema into an equivalent Hive TypeInfo.
+   * @param schema to record. Must be of record type.
+   * @param seenSchemas stores schemas processed in the parsing done so far,
+   *         helping to resolve circular references in the schema
+   * @return TypeInfo matching the Avro schema
+   * @throws AvroSerdeException for any problems during conversion.
+   */
+  public static TypeInfo generateTypeInfo(Schema schema,
+      Set<Schema> seenSchemas) throws AvroSerdeException {
+    // For bytes type, it can be mapped to decimal.
+    Schema.Type type = schema.getType();
+    if (type == BYTES && AvroSerDe.DECIMAL_TYPE_NAME
+        .equalsIgnoreCase(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
+      int precision = 0;
+      int scale = 0;
+      try {
+        precision = getIntValue(schema.getObjectProp(AvroSerDe.AVRO_PROP_PRECISION));
+        scale = getIntValue(schema.getObjectProp(AvroSerDe.AVRO_PROP_SCALE));
+      } catch (Exception ex) {
+        throw new AvroSerdeException("Failed to obtain scale value from file schema: " + schema, ex);
+      }
+
+      try {
+        HiveDecimalUtils.validateParameter(precision, scale);
+      } catch (Exception ex) {
+        throw new AvroSerdeException("Invalid precision or scale for decimal type", ex);
+      }
+
+      return TypeInfoFactory.getDecimalTypeInfo(precision, scale);
+    }
+
+    if (type == STRING &&
+        AvroSerDe.CHAR_TYPE_NAME.equalsIgnoreCase(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
+      int maxLength = 0;
+      try {
+        maxLength = getIntValue(schema.getObjectProp(AvroSerDe.AVRO_PROP_MAX_LENGTH));
+      } catch (Exception ex) {
+        throw new AvroSerdeException("Failed to obtain maxLength value from file schema: " + schema, ex);
+      }
+      return TypeInfoFactory.getCharTypeInfo(maxLength);
+    }
+
+    if (type == STRING && AvroSerDe.VARCHAR_TYPE_NAME
+        .equalsIgnoreCase(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
+      int maxLength = 0;
+      try {
+        maxLength = getIntValue(schema.getObjectProp(AvroSerDe.AVRO_PROP_MAX_LENGTH));
+      } catch (Exception ex) {
+        throw new AvroSerdeException("Failed to obtain maxLength value from file schema: " + schema, ex);
+      }
+      return TypeInfoFactory.getVarcharTypeInfo(maxLength);
+    }
+
+    if (type == INT &&
+        AvroSerDe.DATE_TYPE_NAME.equals(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
+      return TypeInfoFactory.dateTypeInfo;
+    }
+
+    if (type == LONG &&
+        AvroSerDe.TIMESTAMP_TYPE_NAME.equals(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
+      return TypeInfoFactory.timestampTypeInfo;
+    }
+
+    return typeInfoCache.retrieve(schema, seenSchemas);
+  }
+
+  private static int getIntValue(Object obj) {
+    int value = 0;
+    if (obj instanceof Integer) {
+      value = (int) obj;
+    } else if (obj instanceof String && StringUtils.isNumeric((String)obj)) {
+      value = Integer.parseInt((String)obj);
+    }
+    return value;
+  }
+
+  private static TypeInfo generateTypeInfoWorker(Schema schema,
+      Set<Schema> seenSchemas) throws AvroSerdeException {
+    // Avro requires NULLable types to be defined as unions of some type T
+    // and NULL.  This is annoying and we're going to hide it from the user.
+    if(AvroSerdeUtils.isNullableType(schema)) {
+      return generateTypeInfo(
+          AvroSerdeUtils.getOtherTypeFromNullableType(schema), seenSchemas);
+    }
+
+    Schema.Type type = schema.getType();
+    if(primitiveTypeToTypeInfo.containsKey(type)) {
+      return primitiveTypeToTypeInfo.get(type);
+    }
+
+    switch(type) {
+      case RECORD: return generateRecordTypeInfo(schema, seenSchemas);
+      case MAP:    return generateMapTypeInfo(schema, seenSchemas);
+      case ARRAY:  return generateArrayTypeInfo(schema, seenSchemas);
+      case UNION:  return generateUnionTypeInfo(schema, seenSchemas);
+      case ENUM:   return generateEnumTypeInfo(schema);
+      default:     throw new AvroSerdeException("Do not yet support: " + schema);
+    }
+  }
+
+  private static TypeInfo generateRecordTypeInfo(Schema schema,
+      Set<Schema> seenSchemas) throws AvroSerdeException {
+    assert schema.getType().equals(Schema.Type.RECORD);
+
+    if (seenSchemas == null) {
+      seenSchemas = Collections.newSetFromMap(new IdentityHashMap<Schema, Boolean>());
+    } else if (seenSchemas.contains(schema)) {
+      throw new AvroSerdeException(
+          "Recursive schemas are not supported. Recursive schema was " + schema
+              .getFullName());
+    }
+    seenSchemas.add(schema);
+
+    List<Schema.Field> fields = schema.getFields();
+    List<String> fieldNames = new ArrayList<String>(fields.size());
+    List<TypeInfo> typeInfos = new ArrayList<TypeInfo>(fields.size());
+
+    for(int i = 0; i < fields.size(); i++) {
+      fieldNames.add(i, fields.get(i).name());
+      typeInfos.add(i, generateTypeInfo(fields.get(i).schema(), seenSchemas));
+    }
+
+    return TypeInfoFactory.getStructTypeInfo(fieldNames, typeInfos);
+  }
+
+  /**
+   * Generate a TypeInfo for an Avro Map.  This is made slightly simpler in that
+   * Avro only allows maps with strings for keys.
+   */
+  private static TypeInfo generateMapTypeInfo(Schema schema,
+      Set<Schema> seenSchemas) throws AvroSerdeException {
+    assert schema.getType().equals(Schema.Type.MAP);
+    Schema valueType = schema.getValueType();
+    TypeInfo ti = generateTypeInfo(valueType, seenSchemas);
+
+    return TypeInfoFactory.getMapTypeInfo(TypeInfoFactory.getPrimitiveTypeInfo("string"), ti);
+  }
+
+  private static TypeInfo generateArrayTypeInfo(Schema schema,
+      Set<Schema> seenSchemas) throws AvroSerdeException {
+    assert schema.getType().equals(Schema.Type.ARRAY);
+    Schema itemsType = schema.getElementType();
+    TypeInfo itemsTypeInfo = generateTypeInfo(itemsType, seenSchemas);
+
+    return TypeInfoFactory.getListTypeInfo(itemsTypeInfo);
+  }
+
+  private static TypeInfo generateUnionTypeInfo(Schema schema,
+      Set<Schema> seenSchemas) throws AvroSerdeException {
+    assert schema.getType().equals(Schema.Type.UNION);
+    List<Schema> types = schema.getTypes();
+
+
+    List<TypeInfo> typeInfos = new ArrayList<TypeInfo>(types.size());
+
+    for(Schema type : types) {
+      typeInfos.add(generateTypeInfo(type, seenSchemas));
+    }
+
+    return TypeInfoFactory.getUnionTypeInfo(typeInfos);
+  }
+
+  // Hive doesn't have an Enum type, so we're going to treat them as Strings.
+  // During the deserialize/serialize stage we'll check for enumness and
+  // convert as such.
+  private static TypeInfo generateEnumTypeInfo(Schema schema) {
+    assert schema.getType().equals(Schema.Type.ENUM);
+
+    return TypeInfoFactory.getPrimitiveTypeInfo("string");
+  }
+}

--- a/src/main/java/org/apache/hadoop/hive/serde2/avro/TypeInfoToSchema.java
+++ b/src/main/java/org/apache/hadoop/hive/serde2/avro/TypeInfoToSchema.java
@@ -1,0 +1,279 @@
+/*
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.serde2.avro;
+
+import org.apache.avro.JsonProperties;
+import org.apache.avro.Schema;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Convert Hive TypeInfo to an Avro Schema
+ */
+public class TypeInfoToSchema {
+
+  private long recordCounter = 0;
+
+  /**
+   * Converts Hive schema to avro schema
+   *
+   * @param columnNames Names of the hive columns
+   * @param columnTypes Hive Column types
+   * @param namespace   Namespace of Avro schema
+   * @param name        Avro schema name
+   * @param doc         Avro schema doc
+   * @return Avro Schema
+   */
+  public Schema convert(List<String> columnNames, List<TypeInfo> columnTypes,
+      List<String> columnComments, String namespace, String name, String doc) {
+
+    List<Schema.Field> fields = new ArrayList<Schema.Field>();
+    for (int i = 0; i < columnNames.size(); ++i) {
+      final String comment = columnComments.size() > i ? columnComments.get(i) : null;
+      final Schema.Field avroField = createAvroField(columnNames.get(i), columnTypes.get(i),
+          comment);
+      fields.addAll(getFields(avroField));
+    }
+
+    if (name == null || name.isEmpty()) {
+      name = "baseRecord";
+    }
+
+    Schema avroSchema = Schema.createRecord(name, doc, namespace, false);
+    avroSchema.setFields(fields);
+    return avroSchema;
+  }
+
+  private Schema.Field createAvroField(String name, TypeInfo typeInfo, String comment) {
+    return new Schema.Field(name, createAvroSchema(typeInfo), comment, JsonProperties.NULL_VALUE);
+  }
+
+  private Schema createAvroSchema(TypeInfo typeInfo) {
+    Schema schema = null;
+    switch (typeInfo.getCategory()) {
+      case PRIMITIVE:
+        schema = createAvroPrimitive(typeInfo);
+        break;
+      case LIST:
+        schema = createAvroArray(typeInfo);
+        break;
+      case MAP:
+        schema = createAvroMap(typeInfo);
+        break;
+      case STRUCT:
+        schema = createAvroRecord(typeInfo);
+        break;
+      case UNION:
+        schema = createAvroUnion(typeInfo);
+        break;
+    }
+
+    return wrapInUnionWithNull(schema);
+  }
+
+  private Schema createAvroPrimitive(TypeInfo typeInfo) {
+    PrimitiveTypeInfo primitiveTypeInfo = (PrimitiveTypeInfo) typeInfo;
+    Schema schema;
+    switch (primitiveTypeInfo.getPrimitiveCategory()) {
+      case STRING:
+        schema = Schema.create(Schema.Type.STRING);
+        break;
+      case CHAR:
+        schema = AvroSerdeUtils.getSchemaFor("{" +
+            "\"type\":\"" + AvroSerDe.AVRO_STRING_TYPE_NAME + "\"," +
+            "\"logicalType\":\"" + AvroSerDe.CHAR_TYPE_NAME + "\"," +
+            "\"maxLength\":" + ((CharTypeInfo) typeInfo).getLength() + "}");
+        break;
+      case VARCHAR:
+        schema = AvroSerdeUtils.getSchemaFor("{" +
+            "\"type\":\"" + AvroSerDe.AVRO_STRING_TYPE_NAME + "\"," +
+            "\"logicalType\":\"" + AvroSerDe.VARCHAR_TYPE_NAME + "\"," +
+            "\"maxLength\":" + ((VarcharTypeInfo) typeInfo).getLength() + "}");
+        break;
+      case BINARY:
+        schema = Schema.create(Schema.Type.BYTES);
+        break;
+      case BYTE:
+        schema = Schema.create(Schema.Type.INT);
+        break;
+      case SHORT:
+        schema = Schema.create(Schema.Type.INT);
+        break;
+      case INT:
+        schema = Schema.create(Schema.Type.INT);
+        break;
+      case LONG:
+        schema = Schema.create(Schema.Type.LONG);
+        break;
+      case FLOAT:
+        schema = Schema.create(Schema.Type.FLOAT);
+        break;
+      case DOUBLE:
+        schema = Schema.create(Schema.Type.DOUBLE);
+        break;
+      case BOOLEAN:
+        schema = Schema.create(Schema.Type.BOOLEAN);
+        break;
+      case DECIMAL:
+        DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+        String precision = String.valueOf(decimalTypeInfo.precision());
+        String scale = String.valueOf(decimalTypeInfo.scale());
+        schema = AvroSerdeUtils.getSchemaFor("{" +
+            "\"type\":\"bytes\"," +
+            "\"logicalType\":\"decimal\"," +
+            "\"precision\":" + precision + "," +
+            "\"scale\":" + scale + "}");
+        break;
+      case DATE:
+        schema = AvroSerdeUtils.getSchemaFor("{" +
+            "\"type\":\"" + AvroSerDe.AVRO_INT_TYPE_NAME + "\"," +
+            "\"logicalType\":\"" + AvroSerDe.DATE_TYPE_NAME + "\"}");
+        break;
+      case TIMESTAMP:
+        schema = AvroSerdeUtils.getSchemaFor("{" +
+            "\"type\":\"" + AvroSerDe.AVRO_LONG_TYPE_NAME + "\"," +
+            "\"logicalType\":\"" + AvroSerDe.TIMESTAMP_TYPE_NAME + "\"}");
+        break;
+      case VOID:
+        schema = Schema.create(Schema.Type.NULL);
+        break;
+      default:
+        throw new UnsupportedOperationException(typeInfo + " is not supported.");
+    }
+    return schema;
+  }
+
+  private Schema createAvroUnion(TypeInfo typeInfo) {
+    List<Schema> childSchemas = new ArrayList<Schema>();
+    for (TypeInfo childTypeInfo : ((UnionTypeInfo) typeInfo).getAllUnionObjectTypeInfos()) {
+      final Schema childSchema = createAvroSchema(childTypeInfo);
+      if (childSchema.getType() == Schema.Type.UNION) {
+        childSchemas.addAll(childSchema.getTypes());
+      } else {
+        childSchemas.add(childSchema);
+      }
+    }
+
+    return Schema.createUnion(removeDuplicateNullSchemas(childSchemas));
+  }
+
+  private Schema createAvroRecord(TypeInfo typeInfo) {
+    List<Schema.Field> childFields = new ArrayList<Schema.Field>();
+
+    final List<String> allStructFieldNames =
+        ((StructTypeInfo) typeInfo).getAllStructFieldNames();
+    final List<TypeInfo> allStructFieldTypeInfos =
+        ((StructTypeInfo) typeInfo).getAllStructFieldTypeInfos();
+    if (allStructFieldNames.size() != allStructFieldTypeInfos.size()) {
+      throw new IllegalArgumentException("Failed to generate avro schema from hive schema. " +
+          "name and column type differs. names = " + allStructFieldNames + ", types = " +
+          allStructFieldTypeInfos);
+    }
+
+    for (int i = 0; i < allStructFieldNames.size(); ++i) {
+      final TypeInfo childTypeInfo = allStructFieldTypeInfos.get(i);
+      final Schema.Field grandChildSchemaField = createAvroField(allStructFieldNames.get(i),
+          childTypeInfo, childTypeInfo.toString());
+      final List<Schema.Field> grandChildFields = getFields(grandChildSchemaField);
+      childFields.addAll(grandChildFields);
+    }
+
+    Schema recordSchema = Schema.createRecord("record_" + recordCounter, typeInfo.toString(),
+        null, false);
+    ++recordCounter;
+    recordSchema.setFields(childFields);
+    return recordSchema;
+  }
+
+  private Schema createAvroMap(TypeInfo typeInfo) {
+    TypeInfo keyTypeInfo = ((MapTypeInfo) typeInfo).getMapKeyTypeInfo();
+    if (((PrimitiveTypeInfo) keyTypeInfo).getPrimitiveCategory()
+        != PrimitiveObjectInspector.PrimitiveCategory.STRING) {
+      throw new UnsupportedOperationException("Key of Map can only be a String");
+    }
+
+    TypeInfo valueTypeInfo = ((MapTypeInfo) typeInfo).getMapValueTypeInfo();
+    Schema valueSchema = createAvroSchema(valueTypeInfo);
+
+    return Schema.createMap(valueSchema);
+  }
+
+  private Schema createAvroArray(TypeInfo typeInfo) {
+    ListTypeInfo listTypeInfo = (ListTypeInfo) typeInfo;
+    Schema listSchema = createAvroSchema(listTypeInfo.getListElementTypeInfo());
+    return Schema.createArray(listSchema);
+  }
+
+  private List<Schema.Field> getFields(Schema.Field schemaField) {
+    List<Schema.Field> fields = new ArrayList<Schema.Field>();
+
+    JsonProperties.Null nullDefault = JsonProperties.NULL_VALUE;
+    if (schemaField.schema().getType() == Schema.Type.RECORD) {
+      for (Schema.Field field : schemaField.schema().getFields()) {
+        fields.add(new Schema.Field(field.name(), field.schema(), field.doc(), nullDefault));
+      }
+    } else {
+      fields.add(new Schema.Field(schemaField.name(), schemaField.schema(), schemaField.doc(),
+          nullDefault));
+    }
+
+    return fields;
+  }
+
+  private Schema wrapInUnionWithNull(Schema schema) {
+    Schema wrappedSchema = schema;
+    switch (schema.getType()) {
+      case NULL:
+        break;
+      case UNION:
+        List<Schema> existingSchemas = removeDuplicateNullSchemas(schema.getTypes());
+        wrappedSchema = Schema.createUnion(existingSchemas);
+        break;
+      default:
+        wrappedSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), schema));
+    }
+
+    return wrappedSchema;
+  }
+
+  private List<Schema> removeDuplicateNullSchemas(List<Schema> childSchemas) {
+    List<Schema> prunedSchemas = new ArrayList<Schema>();
+    boolean isNullPresent = false;
+    for (Schema schema : childSchemas) {
+      if (schema.getType() == Schema.Type.NULL) {
+        isNullPresent = true;
+      } else {
+        prunedSchemas.add(schema);
+      }
+    }
+    if (isNullPresent) {
+      prunedSchemas.add(0, Schema.create(Schema.Type.NULL));
+    }
+
+    return prunedSchemas;
+  }
+}


### PR DESCRIPTION
Hi @shangxinli,  just copied you changes from hive project.  

Looks like it fixed some of the test failures in prestodb project,  but quite a few avro tests are still failing.

Personally, I don't want to copy too many classes from hive into this project.  What do you think? 

![image](https://user-images.githubusercontent.com/7077075/132778130-72bc1dbf-50ca-4768-90c5-14cd9a461531.png)

{code}
java.lang.NoSuchMethodError: 'com.facebook.presto.hive.$internal.org.codehaus.jackson.JsonNode org.apache.avro.Schema.getJsonProp(java.lang.String)'

	at org.apache.hadoop.hive.serde2.avro.AvroDeserializer.deserializePrimitive(AvroDeserializer.java:285)
	at org.apache.hadoop.hive.serde2.avro.AvroDeserializer.worker(AvroDeserializer.java:225)
	at org.apache.hadoop.hive.serde2.avro.AvroDeserializer.workerBase(AvroDeserializer.java:193)
	at org.apache.hadoop.hive.serde2.avro.AvroDeserializer.deserialize(AvroDeserializer.java:179)
	at org.apache.hadoop.hive.serde2.avro.AvroSerDe.deserialize(AvroSerDe.java:230)
	at com.facebook.presto.hive.GenericHiveRecordCursor.advanceNextPosition(GenericHiveRecordCursor.java:221)
	at com.facebook.presto.hive.HiveRecordCursor.advanceNextPosition(HiveRecordCursor.java:175)
	at com.facebook.presto.hive.AbstractTestHiveFileFormats.checkCursor(AbstractTestHiveFileFormats.java:689)
	at com.facebook.presto.hive.TestHiveFileFormats.testCursorProvider(TestHiveFileFormats.java:948)
	at com.facebook.presto.hive.TestHiveFileFormats.access$200(TestHiveFileFormats.java:123)
	at com.facebook.presto.hive.TestHiveFileFormats$FileFormatAssertion.assertRead(TestHiveFileFormats.java:1196)
	at com.facebook.presto.hive.TestHiveFileFormats$FileFormatAssertion.isReadableByRecordCursor(TestHiveFileFormats.java:1144)
	at com.facebook.presto.hive.TestHiveFileFormats.testAvro(TestHiveFileFormats.java:404)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at org.testng.TestRunner.privateRun(TestRunner.java:756)
	at org.testng.TestRunner.run(TestRunner.java:610)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:387)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:382)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
	at org.testng.SuiteRunner.run(SuiteRunner.java:289)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1293)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1218)
	at org.testng.TestNG.runSuites(TestNG.java:1133)
	at org.testng.TestNG.run(TestNG.java:1104)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:109)
{code}
 
