### PR TITLE
exclude Apache Commons Compress from relocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -690,8 +690,20 @@
                                     <shadedPattern>${shadeBase}.com.google.protobuf</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.commons</pattern>
-                                    <shadedPattern>${shadeBase}.org.apache.commons</shadedPattern>
+                                    <pattern>org.apache.commons.codec</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.commons.codec</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.commons.lang</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.commons.lang3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.logging</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.commons.logging</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.facebook.fb303</pattern>


### PR DESCRIPTION
Only relocating the packages underneath `org.apache.commons` that are shaded so that others don't have their references relocated without the corresponding classes being shaded. Specifically, Avro depends on Apache Commons Compress for writing Data Files and compression but it's excluded from the shaded JAR. Any references by Avro classes reference the shaded package.