### PR TITLE
Upgrade parquet to 1.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
 
         <dep.hive.version>3.0.0</dep.hive.version>
 
-        <dep.avro.version>1.10.1</dep.avro.version>
+        <dep.avro.version>1.11.1</dep.avro.version>
         <dep.jodd.version>3.5.2</dep.jodd.version>
-        <dep.parquet.version>1.12.2</dep.parquet.version>
+        <dep.parquet.version>1.13.1</dep.parquet.version>
         <dep.protobuf.version>2.5.0</dep.protobuf.version>
         <dep.slf4j.version>1.7.25</dep.slf4j.version>
 
@@ -662,7 +662,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
Upgrade Parquet to 1.13.1 because https://github.com/prestodb/presto/pull/21189 relies on it.

CC: @tdcmeehan 