### PR TITLE
Upgrade avro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <dep.hive.version>3.0.0</dep.hive.version>
 
-        <dep.avro.version>1.12.0</dep.avro.version>
+        <dep.avro.version>1.12.1</dep.avro.version>
         <dep.jodd.version>3.5.2</dep.jodd.version>
         <dep.parquet.version>1.16.0</dep.parquet.version>
         <dep.protobuf.version>2.5.0</dep.protobuf.version>


### PR DESCRIPTION
## Description
Upgrade avro to version 1.12.1 to fix the [CVE-2025-33042](https://github.com/advisories/GHSA-rp46-r563-jrc7)

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

Presto CI link after upgrading avro : https://github.com/prestodb/presto/pull/27153